### PR TITLE
Changing view to Treeview

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,8 @@ target/
 # written by setuptools_scm
 */_version.py
 
+# Editor and environment files
+.vscode/
 /venv/
 /.idea/
 temp.cl

--- a/README.md
+++ b/README.md
@@ -37,8 +37,6 @@ napari
 ```
 
 ### Conda
-TODO(MS): Test more minimal fresh environment
-
 If you prefer to use conda, you can create a new environment with the following command:
 ```bash
 conda env create -f environment.yml

--- a/README.md
+++ b/README.md
@@ -28,6 +28,23 @@ You can install `napari-folder-browser` via [pip]:
 Contributions are very welcome. Tests can be run with [tox], please ensure
 the coverage at least stays the same before you submit a pull request.
 
+## Development
+### Test the plugin in Napari
+Simply use pip install and run napari to test the plugin in the same environment:
+```bash
+pip install -e .
+napari
+```
+
+### Conda
+TODO(MS): Test more minimal fresh environment
+
+If you prefer to use conda, you can create a new environment with the following command:
+```bash
+conda env create -f environment.yml
+conda activate napari-folder-browser
+```
+
 ## License
 
 Distributed under the terms of the [BSD-3] license,

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,13 @@
+---
+name: napari-folder-browser
+channels:
+  - conda-forge
+dependencies:
+  - python=3.9
+  - pip=23.1
+  - napari-plugin-engine=0.2.0
+  - napari-tools-menu=0.1.19
+
+# Test dependencies (optional)
+  - PyQt5=5.15.10
+  - pytest=8.1.1

--- a/napari_folder_browser/_dock_widget.py
+++ b/napari_folder_browser/_dock_widget.py
@@ -1,3 +1,4 @@
+from fileinput import filename
 from pathlib import Path
 from PyQt5.QtCore import QModelIndex
 from PyQt5.QtWidgets import QAction
@@ -42,6 +43,7 @@ from napari_tools_menu import register_dock_widget
 class FolderBrowser(QWidget):
     viewer: Viewer
     current_directory: Path
+    folder_chooser: FileEdit
     file_system_model: QFileSystemModel
     tree_view: QTreeView
     
@@ -59,19 +61,19 @@ class FolderBrowser(QWidget):
         # Directory selection
         self.current_directory: Path = Path(QFileDialog.getExistingDirectory(self, "Select Directory"))
         self.layout().addWidget(QLabel("Directory"))
-        filename_edit = FileEdit(
+        self.folder_chooser = FileEdit(
             mode=FileDialogMode.EXISTING_DIRECTORY,
             value=self.current_directory,
         )
-        self.layout().addWidget(filename_edit.native)
+        self.layout().addWidget(self.folder_chooser.native)
 
         def directory_changed(*_) -> None:
-            self.current_directory = Path(filename_edit.value)
+            self.current_directory = Path(self.folder_chooser.value)
             self.tree_view.setRootIndex(self.file_system_model.index(self.current_directory.as_posix()))
             # TODO: Check how we can implement search?
             # self.all_files = [f for f in listdir(self.current_directory) if isfile(join(self.current_directory, f))]
 
-        filename_edit.line_edit.changed.connect(directory_changed)
+        self.folder_chooser.line_edit.changed.connect(directory_changed)
 
         # --------------------------------------------
         # Tree view and image selection
@@ -109,6 +111,7 @@ class FolderBrowser(QWidget):
         file_path: str = self.file_system_model.filePath(index)
         if self.file_system_model.isDir(index):
             self.tree_view.setRootIndex(index)
+            self.folder_chooser.value = file_path
         else:
             print(f"Opening file: {file_path}")
             self.viewer.open(file_path)

--- a/napari_folder_browser/_dock_widget.py
+++ b/napari_folder_browser/_dock_widget.py
@@ -53,7 +53,6 @@ class FolderBrowser(QWidget):
     The napari viewer is passed in as an argument to the constructor
     """
     viewer: Viewer
-    current_directory: Path
     folder_chooser: FileEdit
     file_system_model: QFileSystemModel
     proxy_model: DirectoryFriendlyFilterProxyModel
@@ -68,17 +67,21 @@ class FolderBrowser(QWidget):
 
         # --------------------------------------------
         # Directory selection
-        self.current_directory: Path = Path(QFileDialog.getExistingDirectory(self, "Select Directory"))
+        current_directory: Path = Path(QFileDialog.getExistingDirectory(self, "Select Directory"))
         self.layout().addWidget(QLabel("Directory"))
         self.folder_chooser = FileEdit(
             mode=FileDialogMode.EXISTING_DIRECTORY,
-            value=self.current_directory,
+            value=current_directory,
         )
         self.layout().addWidget(self.folder_chooser.native)
 
         def directory_changed(*_) -> None:
-            self.current_directory = Path(self.folder_chooser.value)
-            self.tree_view.setRootIndex(self.file_system_model.index(self.current_directory.as_posix()))
+            current_directory = Path(self.folder_chooser.value)
+            self.tree_view.setRootIndex(
+                self.proxy_model.mapFromSource(
+                    self.file_system_model.index(current_directory.as_posix())
+                )
+            )
 
         self.folder_chooser.line_edit.changed.connect(directory_changed)
 
@@ -91,11 +94,11 @@ class FolderBrowser(QWidget):
 
         # Create search box and connect to proxy model
         self.layout().addWidget(QLabel("File filter"))
-        self.search_field = QLineEdit("*")
+        self.search_field = QLineEdit()
         # Note: We should agree on the best regex interaction to provide here
-        def update_filder(self, text: str) -> None:
+        def update_filter(text: str) -> None:
             self.proxy_model.setFilterRegExp(QRegExp(text, Qt.CaseInsensitive))
-        self.search_field.textChanged.connect(update_filder)
+        self.search_field.textChanged.connect(update_filter)
         search_widget = QWidget()
         search_widget.setLayout(QHBoxLayout())
         search_widget.layout().addWidget(QLabel("Search:"))
@@ -105,17 +108,22 @@ class FolderBrowser(QWidget):
         # Tree view and image selection
         self.tree_view = QTreeView()
         self.tree_view.setModel(self.proxy_model)
-        self.tree_view.setRootIndex(self.file_system_model.index(self.current_directory.as_posix()))
-        
+        # self.tree_view.setRootIndex(self.file_system_model.index(self.current_directory.as_posix()))
+        self.tree_view.setRootIndex(
+            self.proxy_model.mapFromSource(
+                self.file_system_model.index(current_directory.as_posix())
+            )
+        )
+    
         # Enable selecting multiple files for stack viewing (with shift/ctrl)
         self.tree_view.setSelectionMode(QAbstractItemView.ExtendedSelection)
 
         # Connect the double click signal to a slot that opens the file
-        self.tree_view.doubleClicked.connect(self.tree_double_click)
+        self.tree_view.doubleClicked.connect(self.__tree_double_click)
 
         # Enable context menu for multi selection
         self.tree_view.setContextMenuPolicy(Qt.CustomContextMenu)
-        self.tree_view.customContextMenuRequested.connect(self.show_context_menu)
+        self.tree_view.customContextMenuRequested.connect(self.__show_context_menu)
 
         # Hide the columns for size, type, and last modified
         self.tree_view.setHeaderHidden(True)
@@ -125,34 +133,39 @@ class FolderBrowser(QWidget):
         
         self.layout().addWidget(self.tree_view)
 
-    def tree_double_click(self, index: QModelIndex) -> None:
+    def __tree_double_click(self, index: QModelIndex) -> None:
         """Action on double click in the tree model
         
         Opens the selected file or in the folder
+        
+        Args:
+            index: Index of the selected item in the tree view
         """
-        file_path: str = self.file_system_model.filePath(index)
-        if self.file_system_model.isDir(index):
+        # Note: Need to remap indices from proxy to source for file system operations
+        source_index: QModelIndex = self.proxy_model.mapToSource(index)
+        file_path: str = self.file_system_model.filePath(source_index)
+        if self.file_system_model.isDir(source_index):
             self.tree_view.setRootIndex(index)
             self.folder_chooser.value = file_path
         else:
             print(f"Opening file: {file_path}")
             self.viewer.open(file_path)
 
-    def show_context_menu(self, position: QPoint) -> None:
+    def __show_context_menu(self, position: QPoint) -> None:
         """Show a context menu when right-clicking in the tree view"""
         menu = QMenu()
         open_multiple_action: QAction = menu.addAction("Open multiple files")
         open_multiple_action.triggered.connect(
-            lambda: self.open_multi_selection(is_stack=False)
+            lambda: self.__open_multi_selection(is_stack=False)
         )
         open_as_stack_action: QAction = menu.addAction("Open as stack")
         open_as_stack_action.triggered.connect(
-            lambda: self.open_multi_selection(is_stack=True)
+            lambda: self.__open_multi_selection(is_stack=True)
         )
         # Show the menu at the cursor position
         menu.exec_(self.tree_view.viewport().mapToGlobal(position))
 
-    def open_multi_selection(self, is_stack: bool) -> None:
+    def __open_multi_selection(self, is_stack: bool) -> None:
         """Open multiple files in the viewer
         
         The files are selected in the tree view

--- a/napari_folder_browser/_dock_widget.py
+++ b/napari_folder_browser/_dock_widget.py
@@ -1,9 +1,30 @@
+from pathlib import Path
+from PyQt5.QtCore import QModelIndex
+from PyQt5.QtWidgets import QAction
 from napari_plugin_engine import napari_hook_implementation
-from qtpy.QtWidgets import QWidget, QHBoxLayout, QVBoxLayout, QPushButton, QLineEdit, QListWidget, QListWidgetItem, QLabel, QFileDialog
-from qtpy.QtCore import QEvent, Qt
-from qtpy.QtCore import Signal, QObject, QEvent
+from numpy import stack
+from qtpy.QtWidgets import (
+    QAbstractItemView,
+    QMenu,
+    QWidget,
+    QHBoxLayout,
+    QVBoxLayout,
+    QLineEdit,
+    QListWidget,
+    QListWidgetItem,
+    QLabel,
+    QFileDialog,
+    QTreeView,
+)
+from qtpy.QtCore import QPoint, Qt, QDir, Signal
+from qtpy.QtGui import QFileSystemModel
 from magicgui.widgets import FileEdit
 from magicgui.types import FileDialogMode
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from qtpy.QtCore import QModelIndex
 
 from os import listdir
 from os.path import isfile, join
@@ -25,81 +46,163 @@ class MyQLineEdit(QLineEdit):
 
 @register_dock_widget(menu="Utilities > Folder browser")
 class FolderBrowser(QWidget):
+    """Main Widget for the Folder Browser Dock Widget
+    
+    The napari viewer is passed in as an argument to the constructor
+    """
     def __init__(self, napari_viewer):
         super().__init__()
         self.viewer = napari_viewer
 
         self.setLayout(QVBoxLayout())
 
-
         # --------------------------------------------
         # Directory selection
-        file = str(QFileDialog.getExistingDirectory(self, "Select Directory"))
+        top_level_directory: Path = Path(QFileDialog.getExistingDirectory(self, "Select Directory"))
 
-        self.layout().addWidget(QLabel("Directory"))
-        filename_edit = FileEdit(
-            mode=FileDialogMode.EXISTING_DIRECTORY,
-            value=file)
-        self.layout().addWidget(filename_edit.native)
+        # Create file system model & tree view
+        self.file_system_model = QFileSystemModel()
+        self.file_system_model.setRootPath(QDir.rootPath())
 
-        def directory_changed(*args, **kwargs):
-            self.current_directory = str(filename_edit.value.absolute()).replace("\\", "/").replace("//", "/")
-            self.all_files = [f for f in listdir(self.current_directory) if isfile(join(self.current_directory, f))]
+        self.tree_view = QTreeView()
+        self.tree_view.setModel(self.file_system_model)
+        self.tree_view.setRootIndex(self.file_system_model.index(str(top_level_directory)))
+        
+        # Enable selecting multiple files for stack viewing (with shift/ctrl)
+        self.tree_view.setSelectionMode(QAbstractItemView.ExtendedSelection)
 
-            text_changed() # update shown list
+        # Connect the double click signal to a slot that opens the file
+        self.tree_view.doubleClicked.connect(self.tree_double_click)
 
-        filename_edit.line_edit.changed.connect(directory_changed)
+        # Enable context menu for multi selection
+        self.tree_view.setContextMenuPolicy(Qt.CustomContextMenu)
+        self.tree_view.customContextMenuRequested.connect(self.show_context_menu)
+
+        # Hide the columns for size, type, and last modified
+        self.tree_view.setHeaderHidden(True)
+        self.tree_view.hideColumn(1)
+        self.tree_view.hideColumn(2)
+        self.tree_view.hideColumn(3)
+        
+        self.layout().addWidget(self.tree_view)
+
+
+    def tree_double_click(self, index: QModelIndex) -> None:
+        """Action on double click in the tree model
+        
+        Opens the selected file or in the folder
+        """
+        file_path: str = self.file_system_model.filePath(index)
+        if self.file_system_model.isDir(index):
+            self.tree_view.setRootIndex(index)
+        else:
+            print(f"Opening file: {file_path}")
+            self.viewer.open(file_path)
+
+
+    def show_context_menu(self, position: QPoint) -> None:
+        """Show a context menu when right-clicking in the tree view"""
+        menu = QMenu()
+        open_multiple_action: QAction = menu.addAction("Open multiple files")
+        open_multiple_action.triggered.connect(
+            lambda: self.open_multi_selection(is_stack=False)
+        )
+        open_as_stack_action: QAction = menu.addAction("Open as stack")
+        open_as_stack_action.triggered.connect(
+            lambda: self.open_multi_selection(is_stack=True)
+        )
+        # Show the menu at the cursor position
+        menu.exec_(self.tree_view.viewport().mapToGlobal(position))
+
+
+    def open_multi_selection(self, is_stack: bool) -> None:
+        """Open multiple files in the viewer
+        
+        The files are selected in the tree view
+        
+        Args:
+            is_stack: If True, the files are opened as a stack
+        """
+        # The selection model returns the index for every column
+        indices: list[QModelIndex] = self.tree_view.selectionModel().selectedIndexes()
+
+        # We simply ignore folders in the multi-selection
+        fs_paths: list[str] = [
+            self.file_system_model.filePath(index) for index in indices
+            if not self.file_system_model.isDir(index) and index.column() == 0
+        ]
+
+        # Nothing to do when there is no file selected
+        if len(fs_paths) == 0:
+            return
+
+        self.viewer.open(fs_paths, stack=is_stack)
+
+        # self.layout().addWidget(QLabel("Directory"))
+        # filename_edit = FileEdit(
+        #     mode=FileDialogMode.EXISTING_DIRECTORY,
+        #     value=top_level_directory,
+        # )
+        # self.layout().addWidget(filename_edit.native)
+
+        # def directory_changed(*_) -> None:
+        #     self.current_directory = str(filename_edit.value.absolute()).replace("\\", "/").replace("//", "/")
+        #     self.all_files = [f for f in listdir(self.current_directory) if isfile(join(self.current_directory, f))]
+
+        #     text_changed() # update shown list
+
+        # filename_edit.line_edit.changed.connect(directory_changed)
 
         # --------------------------------------------
         #  File filter
-        self.layout().addWidget(QLabel("File filter"))
-        seach_field = MyQLineEdit("*")
-        results = QListWidget()
+        # self.layout().addWidget(QLabel("File filter"))
+        # seach_field = MyQLineEdit("*")
+        # results = QListWidget()
 
-        # update search
-        def text_changed(*args, **kwargs):
-            search_string = seach_field.text()
+        # # update search
+        # def text_changed(*args, **kwargs):
+        #     search_string = seach_field.text()
 
-            results.clear()
-            for file_name in self.all_files:
-                if fnmatch.fnmatch(file_name, search_string):
-                    _add_result(results, file_name)
-            results.sortItems()
+        #     results.clear()
+        #     for file_name in self.all_files:
+        #         if fnmatch.fnmatch(file_name, search_string):
+        #             _add_result(results, file_name)
+        #     results.sortItems()
 
-        # navigation in the list
-        def key_up():
-            if results.currentRow() > 0:
-                results.setCurrentRow(results.currentRow() - 1)
+        # # navigation in the list
+        # def key_up():
+        #     if results.currentRow() > 0:
+        #         results.setCurrentRow(results.currentRow() - 1)
 
-        def key_down():
-            if results.currentRow() < results.count() - 1:
-                results.setCurrentRow(results.currentRow() + 1)
+        # def key_down():
+        #     if results.currentRow() < results.count() - 1:
+        #         results.setCurrentRow(results.currentRow() + 1)
 
-        seach_field.keyup.connect(key_up)
-        seach_field.keydown.connect(key_down)
-        seach_field.textChanged.connect(text_changed)
+        # seach_field.keyup.connect(key_up)
+        # seach_field.keydown.connect(key_down)
+        # seach_field.textChanged.connect(text_changed)
 
-        # open file on ENTER and double click
-        def item_double_clicked():
-            item = results.currentItem()
-            print("opening", item.file_name)
-            self.viewer.open(join(self.current_directory, item.file_name))
+        # # open file on ENTER and double click
+        # def item_double_clicked():
+        #     item = results.currentItem()
+        #     print("opening", item.file_name)
+        #     self.viewer.open(join(self.current_directory, item.file_name))
 
-        seach_field.returnPressed.connect(item_double_clicked)
-        #results.itemDoubleClicked.connect(item_double_clicked)
-        results.itemActivated.connect(item_double_clicked)
+        # seach_field.returnPressed.connect(item_double_clicked)
+        # #results.itemDoubleClicked.connect(item_double_clicked)
+        # results.itemActivated.connect(item_double_clicked)
 
-        self.setLayout(QVBoxLayout())
+        # self.setLayout(QVBoxLayout())
 
-        w = QWidget()
-        w.setLayout(QHBoxLayout())
-        w.layout().addWidget(QLabel("Search:"))
-        w.layout().addWidget(seach_field)
-        self.layout().addWidget(w)
+        # w = QWidget()
+        # w.setLayout(QHBoxLayout())
+        # w.layout().addWidget(QLabel("Search:"))
+        # w.layout().addWidget(seach_field)
+        # self.layout().addWidget(w)
 
-        self.layout().addWidget(results)
+        # self.layout().addWidget(results)
 
-        directory_changed() # run once to initialize
+        # directory_changed() # run once to initialize
 
 
 def _add_result(results, file_name):
@@ -111,3 +214,11 @@ def _add_result(results, file_name):
 @napari_hook_implementation
 def napari_experimental_provide_dock_widget():
     return [FolderBrowser]
+
+
+if __name__ == "__main__":
+    # Just for running in Debugger
+    import napari
+
+    viewer = napari.Viewer()
+    napari.run()

--- a/napari_folder_browser/_dock_widget.py
+++ b/napari_folder_browser/_dock_widget.py
@@ -1,6 +1,4 @@
 from pathlib import Path
-from PyQt5.QtCore import QModelIndex
-from PyQt5.QtWidgets import QAction
 from napari_plugin_engine import napari_hook_implementation
 from qtpy.QtWidgets import (
     QAbstractItemView,
@@ -13,7 +11,14 @@ from qtpy.QtWidgets import (
     QLineEdit,
     QTreeView,
 )
-from qtpy.QtCore import QPoint, QRegExp, QSortFilterProxyModel, Qt, QDir
+from qtpy.QtCore import  (
+    QDir,
+    QModelIndex,
+    QPoint,
+    QRegExp,
+    QSortFilterProxyModel,
+    Qt,
+)
 from qtpy.QtGui import QFileSystemModel
 from napari.viewer import Viewer
 from magicgui.widgets import FileEdit
@@ -108,7 +113,6 @@ class FolderBrowser(QWidget):
         # Tree view and image selection
         self.tree_view = QTreeView()
         self.tree_view.setModel(self.proxy_model)
-        # self.tree_view.setRootIndex(self.file_system_model.index(self.current_directory.as_posix()))
         self.tree_view.setRootIndex(
             self.proxy_model.mapFromSource(
                 self.file_system_model.index(current_directory.as_posix())
@@ -154,11 +158,11 @@ class FolderBrowser(QWidget):
     def __show_context_menu(self, position: QPoint) -> None:
         """Show a context menu when right-clicking in the tree view"""
         menu = QMenu()
-        open_multiple_action: QAction = menu.addAction("Open multiple files")
+        open_multiple_action = menu.addAction("Open multiple files")
         open_multiple_action.triggered.connect(
             lambda: self.__open_multi_selection(is_stack=False)
         )
-        open_as_stack_action: QAction = menu.addAction("Open as stack")
+        open_as_stack_action = menu.addAction("Open as stack")
         open_as_stack_action.triggered.connect(
             lambda: self.__open_multi_selection(is_stack=True)
         )
@@ -178,8 +182,8 @@ class FolderBrowser(QWidget):
 
         # We simply ignore folders in the multi-selection
         fs_paths: list[str] = [
-            self.file_system_model.filePath(index) for index in indices
-            if not self.file_system_model.isDir(index) and index.column() == 0
+            self.file_system_model.filePath(self.proxy_model.mapToSource(index)) for index in indices
+            if not self.file_system_model.isDir(self.proxy_model.mapToSource(index)) and index.column() == 0
         ]
 
         # Nothing to do when there is no file selected

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,6 @@ python_requires = >=3.7
 # add your package requirements here
 install_requires =
     napari-plugin-engine>=0.1.4
-    numpy
     napari-tools-menu
 
 


### PR DESCRIPTION
For me, exploring my datasets "VS-Code-like" using the tree view is much more efficient, so here the proposed PR :-)

Let me know if it changes the original intent too much and should be a separate plugin instead.

Some notes:
- I prefer the Conda + Poetry combination but did a half-baked Conda environment file which we might want to remove again
- The up and down keystrokes seem to already be mapped in the TreeView
- The search box currently doesn't properly support regex, we could look further into this (do we want case insensitivity?) - The `DirectoryFriendlyFilterProxyModel` is created such that we only filter on the filenames as I think that's the default use case
- Double-click on a folder changes the root directory, on an image it opens as before
- Right-click when multi-select (shift-click) opens the context menu to either open the images separately or as a stack
